### PR TITLE
support first argument of markdown as blessed string like Text::Xslate::Type::Raw.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ perl_version    '5.008';
 requires        'Digest::MD5'     => undef;
 requires        'Text::Balanced'  => undef;
 requires        'Encode'          => undef;
+requires        'Scalar::Util'    => undef;
 test_requires  'Test::More'      => '0.42';
 test_requires  'Test::Exception' => undef;
 test_requires  'List::MoreUtils' => undef;

--- a/lib/Text/Markdown.pm
+++ b/lib/Text/Markdown.pm
@@ -7,6 +7,7 @@ use re 'eval';
 use Digest::MD5 qw(md5_hex);
 use Encode      qw();
 use Carp        qw(croak);
+use Scalar::Util qw(blessed);
 use base        'Exporter';
 
 our $VERSION   = '1.000031'; # 1.0.31
@@ -186,7 +187,7 @@ sub markdown {
     my ( $self, $text, $options ) = @_;
 
     # Detect functional mode, and create an instance for this run
-    unless (ref $self) {
+    unless (blessed($self) && $self->isa('Text::Markdown')) {
         if ( $self ne __PACKAGE__ ) {
             my $ob = __PACKAGE__->new();
                                 # $self is text, $text is options

--- a/t/50blessed-string.t
+++ b/t/50blessed-string.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Text::Markdown qw(markdown);
+
+plan tests => 1;
+
+{
+    # emulate class like Text::Xslate::Type::Raw
+    package    #
+      StringClass;
+
+    use overload (
+        q{""} => sub { ${ $_[0] } },
+        fallback => 1,
+    );
+    sub new {
+        my ($class, $str) = @_;
+        bless \$str, $class;
+    }
+}
+
+my $src = StringClass->new('foo');
+is(markdown($src), "<p>foo</p>\n");
+


### PR DESCRIPTION
markdown with xslate.

This is a example failing code:

```
use strict;
use warnings;
use utf8;
use File::Spec;
use File::Basename;
use lib File::Spec->catdir(dirname(__FILE__), 'extlib', 'lib', 'perl5');
use lib File::Spec->catdir(dirname(__FILE__), 'lib');
use Plack::Builder;
use Amon2::Lite;

use Text::Xslate qw/html_builder mark_raw/;
use Text::Markdown qw/markdown/;

sub config {
    +{
        'Text::Xslate' => {
            'function' => {
                markdown     => html_builder { Text::Markdown::markdown(@_) },
            },
        }
    }
}

get '/markdown_sample' => sub { $_[0]->render('markdown_sample.tx')  };

builder {
    enable 'Plack::Middleware::Static',
        path => qr{^(?:/static/|/robot\.txt$|/favicon\.ico$)},
        root => File::Spec->catdir(dirname(__FILE__));
    enable 'Plack::Middleware::ReverseProxy';
    enable 'Plack::Middleware::Session';

    __PACKAGE__->to_app();
};

__DATA__
@@ markdown_sample.tx
<!doctype html>
<html>
<body>

<pre>
[% FILTER markdown %]
    [% INCLUDE 'docs.txt' %]
[% END %]
</pre>

</body>
</html>

@@ docs.txt
text
```
