### PR TITLE
Generate link in markdown enabled tag

### DIFF
--- a/t/05markdown_in_divs.t
+++ b/t/05markdown_in_divs.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 21;
+use Test::More tests => 23;
 use Test::Differences;
 use FindBin '$Bin';
 use lib "$Bin/../lib";
@@ -408,4 +408,43 @@ eq_or_diff $html, <<'EOF', $test;
 </code></pre>
 
 <p>Above was code</p>
+EOF
+
+
+#-------------------------------------------------------------------------------
+$test = "without markdown on - cannot generate link";
+$html = $m->markdown(<<"EOF");
+<div style="margin-top: 50px; margin-left: 400px;">
+
+[Text::Markdown][cpan-text-markdown] is really cool!
+
+</div>
+
+[cpan-text-markdown]:    https://metacpan.org/module/Text::Markdown
+
+EOF
+eq_or_diff $html, <<'EOF', $test;
+<div style="margin-top: 50px; margin-left: 400px;">
+
+[Text::Markdown][cpan-text-markdown] is really cool!
+
+</div>
+EOF
+
+
+#-------------------------------------------------------------------------------
+$test = "markdown on - generat link";
+$html = $m->markdown(<<"EOF");
+<div markdown="1" style="margin-top: 50px; margin-left: 400px;">
+
+[Text::Markdown][cpan-text-markdown] is really cool!
+
+</div>
+
+[cpan-text-markdown]:    https://metacpan.org/module/Text::Markdown
+EOF
+eq_or_diff $html, <<'EOF', $test;
+<div style="margin-top: 50px; margin-left: 400px;">
+<p><a href="https://metacpan.org/module/Text::Markdown">Text::Markdown</a> is really cool!</p>
+</div>
 EOF


### PR DESCRIPTION
Since, `_StripLinkDefinitions()` is called after `_HashHTMLBlocks()`,
so current `Text::Markdown` cannot generate link in markdown enabled tag(`markdown="1"`).

I'm not sure if there's side effects on other parts of `Text::Markdown`.
But it seems that the patch fixes the problem.

If this patch is applied, `_Markdown()` method of `Text::MultiMarkdown` has to be changed(removing `_StripLinkDefinitions()`), too.
