### PR TITLE
Add option break_at_newlines adapted from GitHub Flavored Markdown

### DIFF
--- a/lib/Text/Markdown.pm
+++ b/lib/Text/Markdown.pm
@@ -92,6 +92,11 @@ The options for the processor are:
 
 =over
 
+=item break_at_newlines
+
+Converts newlines to linebreaks within block-level tags. This feature was
+adapted from Github Flavored Markdown.
+
 =item empty_element_suffix
 
 This option controls the end of empty element tags:
@@ -169,6 +174,8 @@ sub new {
     $p{empty_element_suffix} ||= ' />'; # Change to ">" for HTML output
 
     $p{trust_list_start_value} = $p{trust_list_start_value} ? 1 : 0;
+
+    $p{break_at_newlines} ||= defined $p{break_at_newlines} ? $p{break_newlines} : 0;
 
     my $self = { params => \%p };
     bless $self, ref($class) || $class;
@@ -579,7 +586,12 @@ sub _RunSpanGamut {
 
     # FIXME - Is hard coding space here sane, or does this want to be related to tab width?
     # Do hard breaks:
-    $text =~ s/ {2,}\n/ <br$self->{empty_element_suffix}\n/g;
+    if ($self->{break_at_newlines}) {
+        $text =~ s/\n/ <br$self->{empty_element_suffix}\n/g;
+    }
+    else {
+        $text =~ s/ {2,}\n/ <br$self->{empty_element_suffix}\n/g;
+    }
 
     return $text;
 }

--- a/t/38_break_at_newlines.t
+++ b/t/38_break_at_newlines.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+BEGIN {
+    unless(eval q{ use Test::Differences; unified_diff; 1 }) {
+        note 'Test::Differences recommended';
+        *eq_or_diff = \&is_deeply;
+    }
+}
+
+use_ok('Text::Markdown', 'markdown');
+
+my $mkdn = <<'END';
+Newlines
+--------
+
+The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.
+
+The next paragraph contains two phrases separated by a single newline character:
+
+    Roses are red
+    Violets are blue
+
+becomes
+
+Roses are red
+Violets are blue
+END
+
+{
+    my $m = Text::Markdown->new( break_at_newlines => 0 );
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'off' );
+<h2>Newlines</h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red
+Violets are blue</p>
+EOF
+}
+
+{
+    my $m = Text::Markdown->new( break_at_newlines => 1 );
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'on');
+<h2>Newlines</h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard <br />
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the <br />
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like <br />
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red <br />
+Violets are blue</p>
+EOF
+}
+
+{
+    my $m = Text::Markdown->new();
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'default' );
+<h2>Newlines</h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red
+Violets are blue</p>
+EOF
+}


### PR DESCRIPTION
This is the same feature that was already provided here:

https://github.com/bobtfish/text-multimarkdown/pull/17
https://github.com/bobtfish/text-markdown/issues/15

However, that implementation is based on the actual GFM implementation in Ruby (which has a ton of issues: https://github.com/github/github-flavored-markdown). It was trivial to add this feature to Text::Markdown.

Although this would probably be more appropriate as a Text::MultiMarkdown feature, looking at the code, it is much saner to implement inside the Text::Markdown parent class.
