### PR TITLE
Nested hashification

### DIFF
--- a/lib/Text/Markdown.pm
+++ b/lib/Text/Markdown.pm
@@ -1369,15 +1369,22 @@ sub _FormParagraphs {
     }
 
     #
-    # Unhashify HTML blocks
+    # Unhashify HTML blocks.  Handles nested hashification, ie. block inside comment.
     #
-    foreach (@grafs) {
-        if (defined( $self->{_html_blocks}{$_} )) {
-            $_ = $self->{_html_blocks}{$_};
+    my @unhashified;
+    while (scalar @grafs) {
+        my $graf = shift @grafs;
+        if (defined( $self->{_html_blocks}{$graf} )) {
+            $graf = $self->{_html_blocks}{$graf};
+            my @subgrafs = split(/\n{2,}/, $graf);
+            unshift @grafs, @subgrafs;
+        }
+        else {
+            push @unhashified, $graf;
         }
     }
 
-    return join "\n\n", @grafs;
+    return join "\n\n", @unhashified;
 }
 
 sub _EncodeAmpsAndAngles {

--- a/t/41blockinsidecomment.t
+++ b/t/41blockinsidecomment.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use_ok('Text::Markdown');
+
+{
+    my $instr = <<EOM;
+<!--
+<div></div>
+-->
+EOM
+    my $expstr = <<EOM;
+<!--
+
+<div></div>
+
+-->
+EOM
+
+    is(Text::Markdown::markdown($instr) => $expstr, 'as expected');
+
+};


### PR DESCRIPTION
Fixes this issue: https://github.com/bobtfish/text-markdown/issues/25

When a block element is inside a comment, the block is hashed out, then the comment is hashed out.  Then on the way back out, the comment is dehashed, leaving the hashed block which is then never dehashed.  Patch includes fix as well as regression test.